### PR TITLE
fix: 건물명 api 변경 및 컬럼명과 데이터 불일치 수정

### DIFF
--- a/src/api/RequestBack.js
+++ b/src/api/RequestBack.js
@@ -12,7 +12,8 @@ export default {
     formData.append('roadName', property.roadName); // 도로명주소
     formData.append('bgdCd', property.bgdCd); // 법정동 코드
     formData.append('dong', property.dong); // 법정동명
-    formData.append('addressName', property.addressName); // 상세주소
+    formData.append('addressName', property.addressName); // 지번주소
+    formData.append('detailAddress', property.detailAddress); // 상세주소
     formData.append('mainAddressNo', property.mainAddressNo); // 본번
     formData.append('subAddressNo', property.subAddressNo); // 부번
     formData.append('longitude', property.longitude); // 경도 _ api 요청해서 받아오기

--- a/src/components/tool/AddressSearch.vue
+++ b/src/components/tool/AddressSearch.vue
@@ -77,10 +77,12 @@ export default {
           if (data.documents.length > 0) {
             const { x, y, main_address_no, sub_address_no } =
               data.documents[0].address;
+            const { building_name } = data.documents[0].road_address;
             this.longitude = x;
             this.latitude = y;
             this.mainAddressNo = main_address_no;
             this.subAddressNo = sub_address_no;
+            this.complexName = building_name;
 
             this.emitAddressData();
           } else {
@@ -137,6 +139,8 @@ export default {
           this.extraAddress = roadAddr ? extraRoadAddr : '';
           this.bcode = data.bcode;
 
+          this.emitAddressData();
+
           try {
             // 주소가 변경될 때 좌표, 본번 부번을 가져옴
             await this.fetchCoordinates();
@@ -168,10 +172,9 @@ export default {
           data.tbLnOpendataRentV.row &&
           data.tbLnOpendataRentV.row.length > 0
         ) {
-          const { BLDG_NM, BLDG_USG, GRFE } = data.tbLnOpendataRentV.row[0];
-          console.log(BLDG_NM, BLDG_USG, GRFE, apiUrl);
+          const { BLDG_USG, GRFE } = data.tbLnOpendataRentV.row[0];
+          console.log(BLDG_USG, GRFE, apiUrl);
 
-          this.complexName = BLDG_NM;
           this.type = BLDG_USG;
           this.recentDeposit = GRFE;
 

--- a/src/pages/AddProperty.vue
+++ b/src/pages/AddProperty.vue
@@ -15,6 +15,7 @@ const property = reactive({
   roadName: '',
   bgdCd: '',
   addressName: '',
+  detailAddress: '',
   mainAddressNo: '',
   subAddressNo: '',
   longitude: '',
@@ -47,9 +48,9 @@ const handleAddressSelected = (addressData) => {
   // Address 컴포넌트에서 emit된 데이터를 property에 저장
   property.zipcode = addressData.postcode;
   property.roadName = addressData.roadAddress;
-  property.mainAddressNo = addressData.jibunAddress;
+  property.addressName = addressData.jibunAddress;
   property.subAddressNo = addressData.extraAddress;
-  property.addressName = addressData.detailAddress;
+  property.detailAddress = addressData.detailAddress;
   property.bgdCd = addressData.bcode;
   property.longitude = addressData.longitude;
   property.latitude = addressData.latitude;
@@ -126,9 +127,9 @@ const register = async () => {
             <AddressSearch @addressSelected="handleAddressSelected" />
             <input
               type="text"
-              id="addressName"
-              name="addressName"
-              v-model="property.addressName"
+              id="detailAddress"
+              name="detailAddress"
+              v-model="property.detailAddress"
               placeholder="상세주소"
             />
           </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #4

## 📝작업 내용

> 건물명 가져오는 api를 부동산 정보 api에서 주소검색 api로 변경( 부동산에 내역이 없어도 건물명 가져올 수 있게)
> 상세주소와 지번주소 컬럼이 헷갈려서 변경하고 상세주소는 새로 컬럼에 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
