### PR TITLE
feat: 전세가율 별 이미지 마커 색상 변경

### DIFF
--- a/src/pages/side/SearchFilter.vue
+++ b/src/pages/side/SearchFilter.vue
@@ -129,7 +129,7 @@ const selectItem = (item) => {
 const onInputChange = async (e) => {
   searchTerm.value = e.target.value;
   if (searchTerm.value == '') showDropdown.value = false;
-  else showDropdown.value = true
+  else showDropdown.value = true;
   complexSuggestion.value = await fetchcomplexSuggestion(searchTerm.value);
 };
 

--- a/src/stores/ComplexesStore.js
+++ b/src/stores/ComplexesStore.js
@@ -82,6 +82,12 @@ export const useComplexesStore = defineStore('map', {
       return `${roundedValue}억`;
     },
 
+    // 전세가율 계산 함수
+    depositRateCal(dep, amo) {
+      let depositRate = (dep / amo) * 100;
+      return depositRate;
+    },
+
     removeAllMarkersAndOverlays() {
       for (let i = 0; i < this.markers.length; i++) {
         this.markers[i].setMap(null); // 맵에서 마커 제거
@@ -109,10 +115,32 @@ export const useComplexesStore = defineStore('map', {
           apt.longitude
         );
 
-        let imageSrc =
-          this.convertToEok(apt.recentDeposit) === '0억'
-            ? '/images/property_gray.png'
-            : '/images/property_KB.png';
+        let imageSrc = '';
+        // if (this.convertToEok(apt.recentDeposit) === '0억') {
+        //   imageSrc = '/images/property_gray.png';
+        // } else {
+        //   imageSrc = '/images/property_KB.png';
+        // }
+        if (this.depositRateCal(apt.recentDeposit, apt.recentAmount) >= 90) {
+          imageSrc = '/images/property_red.png';
+        } else if (
+          this.depositRateCal(apt.recentDeposit, apt.recentAmount) >= 80
+        ) {
+          imageSrc = '/images/property_orange.png';
+        } else if (
+          this.depositRateCal(apt.recentDeposit, apt.recentAmount) >= 70
+        ) {
+          imageSrc = '/images/property_yellow.png';
+        } else if (
+          this.depositRateCal(apt.recentDeposit, apt.recentAmount) >= 60
+        ) {
+          imageSrc = '/images/property_greenL.png';
+        } else if (this.convertToEok(apt.recentDeposit) === '0억') {
+          imageSrc = '/images/property_gray.png';
+        } else {
+          imageSrc = '/images/property_green.png';
+        }
+
         const imageSize = new kakao.maps.Size(60, 60); // 이미지 크기
         const imageOption = { offset: new kakao.maps.Point(30, 80) }; // 마커와 이미지 위치 맞추기
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> -실거래 기준 전세가율을 계산해 구간별로 나누고 이미지 마커 색상을 달리하여 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
